### PR TITLE
Fix project-name filtering in project/task picker

### DIFF
--- a/app/src/main/java/dev/tricked/solidverdant/ui/components/ProjectTaskDropdownMenu.kt
+++ b/app/src/main/java/dev/tricked/solidverdant/ui/components/ProjectTaskDropdownMenu.kt
@@ -108,6 +108,35 @@ fun ProjectTaskDropdown(
 
 private val OutlinedTextFieldDefaultsShape = RoundedCornerShape(4.dp)
 
+internal data class ProjectTaskSearchResults(val projects: List<Project>, val tasksByProject: Map<String, List<Task>>)
+
+internal fun filterProjectsAndTasks(projects: List<Project>, tasks: List<Task>, query: String): ProjectTaskSearchResults {
+    val normalizedQuery = query.trim()
+    if (normalizedQuery.isBlank()) {
+        return ProjectTaskSearchResults(projects, tasks.groupBy { it.projectId })
+    }
+
+    val directlyMatchingProjectIds = projects
+        .asSequence()
+        .filter { it.name.contains(normalizedQuery, ignoreCase = true) }
+        .map { it.id }
+        .toSet()
+    val filteredTasks = tasks.filter { task ->
+        task.projectId in directlyMatchingProjectIds ||
+            task.name.contains(normalizedQuery, ignoreCase = true)
+    }
+    val matchingTaskProjectIds = filteredTasks
+        .asSequence()
+        .filter { it.name.contains(normalizedQuery, ignoreCase = true) }
+        .map { it.projectId }
+        .toSet()
+    val filteredProjects = projects.filter { project ->
+        project.id in directlyMatchingProjectIds || project.id in matchingTaskProjectIds
+    }
+
+    return ProjectTaskSearchResults(filteredProjects, filteredTasks.groupBy { it.projectId })
+}
+
 @Composable
 private fun ProjectTaskPickerDialog(
     projects: List<Project>,
@@ -122,20 +151,9 @@ private fun ProjectTaskPickerDialog(
     onCreateTask: ((String, String) -> Unit)?,
 ) {
     val normalizedQuery = searchQuery.trim()
-    val filteredTasks = remember(normalizedQuery, tasks) {
-        tasks.filter { normalizedQuery.isBlank() || it.name.contains(normalizedQuery, true) }
+    val searchResults = remember(normalizedQuery, projects, tasks) {
+        filterProjectsAndTasks(projects, tasks, normalizedQuery)
     }
-    val matchingTaskProjectIds = remember(filteredTasks, normalizedQuery) {
-        if (normalizedQuery.isBlank()) emptySet() else filteredTasks.map { it.projectId }.toSet()
-    }
-    val filteredProjects = remember(normalizedQuery, projects, matchingTaskProjectIds) {
-        projects.filter {
-            normalizedQuery.isBlank() ||
-                it.name.contains(normalizedQuery, true) ||
-                it.id in matchingTaskProjectIds
-        }
-    }
-    val filteredTasksByProject = remember(filteredTasks) { filteredTasks.groupBy { it.projectId } }
     Dialog(onDismissRequest = onClose) {
         Surface(
             modifier = Modifier
@@ -176,7 +194,7 @@ private fun ProjectTaskPickerDialog(
                         },
                     )
                 }
-                filteredProjects.forEach { project ->
+                searchResults.projects.forEach { project ->
                     item(key = "project_${project.id}") {
                         DropdownMenuItem(
                             text = {
@@ -200,7 +218,7 @@ private fun ProjectTaskPickerDialog(
                         )
                     }
 
-                    filteredTasksByProject[project.id].orEmpty().forEach { task ->
+                    searchResults.tasksByProject[project.id].orEmpty().forEach { task ->
                         item(key = "task_${task.id}") {
                             DropdownMenuItem(
                                 text = {
@@ -245,7 +263,7 @@ private fun ProjectTaskPickerDialog(
                         )
                     }
                 }
-                if (searchQuery.isNotBlank() && filteredProjects.isEmpty()) {
+                if (searchQuery.isNotBlank() && searchResults.projects.isEmpty()) {
                     item {
                         DropdownMenuItem(
                             text = {

--- a/app/src/test/java/dev/tricked/solidverdant/ui/components/ProjectTaskDropdownMenuTest.kt
+++ b/app/src/test/java/dev/tricked/solidverdant/ui/components/ProjectTaskDropdownMenuTest.kt
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package dev.tricked.solidverdant.ui.components
+
+import dev.tricked.solidverdant.data.model.Project
+import dev.tricked.solidverdant.data.model.Task
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProjectTaskDropdownMenuTest {
+    private val matchingProject = project("project-1", "M5337RW - 62201")
+    private val otherProject = project("project-2", "Internal work")
+    private val turningTask = task("task-1", "Turning - Running", matchingProject.id)
+    private val setupTask = task("task-2", "Setup and F/O", matchingProject.id)
+    private val otherTask = task("task-3", "Planning", otherProject.id)
+    private val projects = listOf(matchingProject, otherProject)
+    private val tasks = listOf(turningTask, setupTask, otherTask)
+
+    @Test
+    fun `project name match includes every task in that project`() {
+        val results = filterProjectsAndTasks(projects, tasks, "  m5337  ")
+
+        assertEquals(listOf(matchingProject), results.projects)
+        assertEquals(listOf(turningTask, setupTask), results.tasksByProject[matchingProject.id])
+    }
+
+    @Test
+    fun `task name match includes only matching tasks and their project`() {
+        val results = filterProjectsAndTasks(projects, tasks, "TURNING - RUNNING")
+
+        assertEquals(listOf(matchingProject), results.projects)
+        assertEquals(listOf(turningTask), results.tasksByProject[matchingProject.id])
+    }
+
+    @Test
+    fun `blank query preserves all projects and tasks`() {
+        val results = filterProjectsAndTasks(projects, tasks, "   ")
+
+        assertEquals(projects, results.projects)
+        assertEquals(listOf(turningTask, setupTask), results.tasksByProject[matchingProject.id])
+        assertEquals(listOf(otherTask), results.tasksByProject[otherProject.id])
+    }
+
+    @Test
+    fun `unmatched query returns no projects or tasks`() {
+        val results = filterProjectsAndTasks(projects, tasks, "not present")
+
+        assertEquals(emptyList<Project>(), results.projects)
+        assertEquals(emptyMap<String, List<Task>>(), results.tasksByProject)
+    }
+
+    private fun project(id: String, name: String) = Project(id = id, name = name, color = "#000000")
+
+    private fun task(id: String, name: String, projectId: String) = Task(
+        id = id,
+        name = name,
+        projectId = projectId,
+        createdAt = "2026-08-18T00:00:00Z",
+        updatedAt = "2026-08-18T00:00:00Z",
+    )
+}


### PR DESCRIPTION
## Summary

Fix project/task picker search so matching a project name keeps all tasks belonging to that project visible. Task-name searches continue to show only matching tasks under their parent project.

## Scope and acceptance criteria

- [x] Project-name searches show the matching project and all of its tasks.
- [x] Task-name searches show only matching tasks and their parent project.
- [x] Matching is case-insensitive and ignores surrounding whitespace.
- [x] Blank and unmatched query behavior remains correct.
- [x] Focused regression tests cover the filtering behavior.

## Validation

Commands and focused tests actually run:

```text
.\gradlew.bat --no-daemon :app:testDebugUnitTest --tests dev.tricked.solidverdant.ui.components.ProjectTaskDropdownMenuTest -> passed
.\gradlew.bat --no-daemon spotlessCheck :app:testDebugUnitTest --tests dev.tricked.solidverdant.ui.components.ProjectTaskDropdownMenuTest lintDebug assembleDebug assembleDebugAndroidTest -> BUILD SUCCESSFUL
.\gradlew.bat --no-daemon spotlessCheck testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest -> one unrelated existing failure in TrackingTimeFormattingTest.multi-day range includes both dates
```

Verification status by scope:

- Host/unit/lint: Focused tests, formatting, and lint passed. The full unit suite has one unrelated timezone-sensitive failure in `TrackingTimeFormattingTest`.
- Screenshot/UI: Not run; no layout or styling changed.
- Device/E2E: Not run; this is an isolated filtering change covered by focused unit tests.
- Backend/server evidence: Not applicable; no mutation, sync, repository, or backend behavior changed.

## Evidence and remaining gaps

The debug APK and Android-test APK assemble successfully. The repository-pinned `devenv tasks run android:gate` was not available on the Windows host because `devenv` was not installed. No connected-device test was run.

## Safety and working tree

- [x] No tokens, work data, or machine-specific paths are included.
- [x] Unrelated changes were preserved.
- [x] No generated source artifacts or screenshot baselines were added.